### PR TITLE
Make it compatible with express 4.0.0 +

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,9 +1,7 @@
 var express = require("express");
 var app = express();
 
-app.configure(function() {
-    app.use(express.static(__dirname));
-});
+app.use(express.static(__dirname));
 
 console.log('listening on 2000');
 app.listen(2000);


### PR DESCRIPTION
app.configure has been deprecated since 3.13.0 / 2014-07-03 and is now removed since 4.0.0 / 2014-04-09. See https://github.com/strongloop/express/blob/master/History.md.

localhost socrates.io works fine with this little fix.
